### PR TITLE
Feat/support lb

### DIFF
--- a/mesh-integration-tests/src/test/java/com/netcracker/it/spring/LoadBalanceIT.java
+++ b/mesh-integration-tests/src/test/java/com/netcracker/it/spring/LoadBalanceIT.java
@@ -1,0 +1,143 @@
+package com.netcracker.it.spring;
+
+import com.google.gson.Gson;
+import com.netcracker.cloud.junit.cloudcore.extension.annotations.Cloud;
+import com.netcracker.cloud.junit.cloudcore.extension.annotations.EnableExtension;
+import com.netcracker.it.spring.model.TraceResponse;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Stream;
+
+import static com.netcracker.it.spring.Const.INTERNAL_GW_SERVICE_NAME;
+import static com.netcracker.it.spring.Const.PUBLIC_GW_SERVICE_NAME;
+import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Mesh-agnostic test for stickiness ({@code StatefulSession}) and load-balancing ({@code LoadBalance}) CRs. 
+ * The same behaviour must hold for both meshes; which CRs are applied
+ * is decided by the {@code SERVICE_MESH_TYPE} guards in the mesh-test-service-spring chart
+ * (Core: {@code Mesh subKind: StatefulSession/LoadBalance}; Istio: {@code DestinationRule.consistentHash}).
+ * <p>
+ * Requests go through the public and internal gateways via in-cluster {@code curl} (run inside the
+ * mesh-test-service-spring pod). curl's own cookie jar captures and replays the sticky cookie. 
+ * With {@code REPLICAS: 2} pod pinning is observable via {@code podId}.
+ * <p>
+ */
+@Slf4j
+@EnableExtension
+@Tag("LoadBalance")
+public class LoadBalanceIT {
+
+    private static final String LB_TEST_PATH   = "/api/v1/mesh-test-service-spring/lb-test";
+    private static final String LB_HEADER_PATH = "/api/v1/mesh-test-service-spring/lb-header";
+
+    // Core suffixes the cookie with the b/g version (sticky-cookie-spring-v1); Istio keeps it verbatim.
+    private static final String STICKY_COOKIE_BASE_NAME = "sticky-cookie-spring";
+    private static final String LB_HEADER_NAME          = "X-User-Id";
+
+    private static final int STICKY_REQUESTS = 10;
+    private static final Gson GSON = new Gson();
+
+    @Cloud
+    protected static KubernetesClient kubernetesClient;
+
+    @BeforeAll
+    public static void setUp() {
+        IntegrationTestSupport.init(kubernetesClient);
+        Assumptions.assumeTrue(IntegrationTestSupport.isExecutorAvailable(),
+                "mesh-test-service-spring pod not found — load-balance IT requires in-cluster curl executor");
+    }
+
+    static Stream<Arguments> gateways() {
+        return Stream.of(
+                Arguments.of(PUBLIC_GW_SERVICE_NAME),
+                Arguments.of(INTERNAL_GW_SERVICE_NAME)
+        );
+    }
+
+    // Cookie stickiness: the generated session cookie must pin every request to the same pod.
+    @ParameterizedTest(name = "cookie stickiness via {0}")
+    @MethodSource("gateways")
+    void cookieStickiness_pinsAllRequestsToSamePod(String gateway) throws Exception {
+        String url = IntegrationTestSupport.inClusterServiceUrl(gateway, LB_TEST_PATH);
+        String cookieJar = "/tmp/lb-" + gateway + "-" + UUID.randomUUID() + ".cookies";
+
+        TraceResponse first = awaitTrace(url, "-c", cookieJar);
+        assertTrue(cookieJarContains(cookieJar, STICKY_COOKIE_BASE_NAME),
+                gateway + ": mesh must issue the " + STICKY_COOKIE_BASE_NAME + " cookie");
+        log.info("[{}] sticky cookie issued by pod {}", gateway, first.getPodId());
+
+        Set<String> pods = new LinkedHashSet<>();
+        pods.add(first.getPodId());
+        for (int i = 0; i < STICKY_REQUESTS; i++) {
+            pods.add(awaitTrace(url, "-b", cookieJar).getPodId());
+        }
+        log.info("[{}] pods that served cookie-pinned requests: {}", gateway, pods);
+        assertEquals(1, pods.size(),
+                gateway + ": cookie stickiness must pin every request to a single pod, but saw: " + pods);
+        assertTrue(pods.contains(first.getPodId()),
+                gateway + ": sticky pod must match the pod that issued the cookie");
+    }
+
+    // Header hash: requests with the same X-User-Id must hit the same pod (dedicated host avoids Istio DR collision).
+    @ParameterizedTest(name = "header hash via {0}")
+    @MethodSource("gateways")
+    void headerHash_pinsRequestsWithSameHeaderValueToSamePod(String gateway) {
+        String url = IntegrationTestSupport.inClusterServiceUrl(gateway, LB_HEADER_PATH);
+        String header = LB_HEADER_NAME + ": " + UUID.randomUUID();
+
+        Set<String> pods = new LinkedHashSet<>();
+        for (int i = 0; i < STICKY_REQUESTS; i++) {
+            pods.add(awaitTrace(url, "-H", header).getPodId());
+        }
+        log.info("[{}] pods for '{}': {}", gateway, header, pods);
+        assertEquals(1, pods.size(),
+                gateway + ": header consistent-hash must pin one header value to a single pod, but saw: " + pods);
+    }
+
+    // ── helpers ───────────────────────────────────────────────────────────────────────────────────
+
+    /** curls {@code url} in-cluster, retrying (via awaitility) until it returns a trace with a podId. */
+    private static TraceResponse awaitTrace(String url, String... curlArgs) {
+        AtomicReference<TraceResponse> ref = new AtomicReference<>();
+        await().atMost(Duration.ofMinutes(2))
+                .pollInterval(Duration.ofMillis(IntegrationTestSupport.POLL_INTERVAL_MS))
+                .ignoreExceptions()
+                .until(() -> {
+                    List<String> cmd = new ArrayList<>(List.of("curl", "-s"));
+                    cmd.addAll(Arrays.asList(curlArgs));
+                    cmd.add(url);
+                    String body = IntegrationTestSupport.executeInClusterPod(cmd.toArray(new String[0]));
+                    TraceResponse trace = body == null || body.isBlank()
+                            ? null : GSON.fromJson(body.trim(), TraceResponse.class);
+                    ref.set(trace);
+                    return trace != null && trace.getPodId() != null;
+                });
+        TraceResponse trace = ref.get();
+        assertNotNull(trace, "trace response from " + url);
+        return trace;
+    }
+
+    private static boolean cookieJarContains(String cookieJar, String cookieName) throws Exception {
+        String jar = IntegrationTestSupport.executeInClusterPod("cat", cookieJar);
+        return jar != null && jar.contains(cookieName);
+    }
+}

--- a/mesh-test-service-spring/helm-templates/mesh-test-service-spring/templates/load-balance-core.yaml
+++ b/mesh-test-service-spring/helm-templates/mesh-test-service-spring/templates/load-balance-core.yaml
@@ -69,6 +69,7 @@ metadata:
 spec:
   cluster: mesh-test-service-spring-lb
   version: "{{ .Values.DEPLOYMENT_VERSION }}"
+  endpoint: http://mesh-test-service-spring-lb:8080
   policies:
     - header:
         headerName: X-User-Id

--- a/mesh-test-service-spring/helm-templates/mesh-test-service-spring/templates/load-balance-core.yaml
+++ b/mesh-test-service-spring/helm-templates/mesh-test-service-spring/templates/load-balance-core.yaml
@@ -1,0 +1,75 @@
+{{- if eq .Values.SERVICE_MESH_TYPE "Core" }}
+# Core header-hash LB: /lb-header routes on public + internal gateways to the -lb cluster; LoadBalance
+# (cluster-scoped) hashes by X-User-Id. Separate cluster keeps it off the cookie-stickiness host.
+---
+apiVersion: core.netcracker.com/v1
+kind: Mesh
+subKind: RouteConfiguration
+metadata:
+  name: mesh-test-service-spring-lb-header-routes
+  labels:
+    app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
+    app.kubernetes.io/name: '{{ .Values.SERVICE }}'
+    app.kubernetes.io/processed-by-operator: "core-operator"
+    deployment.netcracker.com/sessionId: '{{ .Values.DEPLOYMENT_SESSION_ID }}'
+spec:
+  gateways: ["public-gateway-service"]
+  virtualServices:
+    - name: public-gateway-service
+      hosts: ["*"]
+      routeConfiguration:
+        version: "{{ .Values.DEPLOYMENT_VERSION }}"
+        routes:
+          - destination:
+              cluster: mesh-test-service-spring-lb
+              endpoint: http://mesh-test-service-spring-lb:8080
+            rules:
+              - match:
+                  prefix: /api/v1/{{ .Values.SERVICE }}/lb-header
+                allowed: true
+                prefixRewrite: /api/v1/hello
+---
+apiVersion: core.netcracker.com/v1
+kind: Mesh
+subKind: RouteConfiguration
+metadata:
+  name: mesh-test-service-spring-lb-header-internal-routes
+  labels:
+    app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
+    app.kubernetes.io/name: '{{ .Values.SERVICE }}'
+    app.kubernetes.io/processed-by-operator: "core-operator"
+    deployment.netcracker.com/sessionId: '{{ .Values.DEPLOYMENT_SESSION_ID }}'
+spec:
+  gateways: ["internal-gateway-service"]
+  virtualServices:
+    - name: internal-gateway-service
+      hosts: ["*"]
+      routeConfiguration:
+        version: "{{ .Values.DEPLOYMENT_VERSION }}"
+        routes:
+          - destination:
+              cluster: mesh-test-service-spring-lb
+              endpoint: http://mesh-test-service-spring-lb:8080
+            rules:
+              - match:
+                  prefix: /api/v1/{{ .Values.SERVICE }}/lb-header
+                allowed: true
+                prefixRewrite: /api/v1/hello
+---
+apiVersion: core.netcracker.com/v1
+kind: Mesh
+subKind: LoadBalance
+metadata:
+  name: mesh-test-service-spring-lb-header
+  labels:
+    app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
+    app.kubernetes.io/name: '{{ .Values.SERVICE }}'
+    app.kubernetes.io/processed-by-operator: "core-operator"
+    deployment.netcracker.com/sessionId: '{{ .Values.DEPLOYMENT_SESSION_ID }}'
+spec:
+  cluster: mesh-test-service-spring-lb
+  version: "{{ .Values.DEPLOYMENT_VERSION }}"
+  policies:
+    - header:
+        headerName: X-User-Id
+{{- end }}

--- a/mesh-test-service-spring/helm-templates/mesh-test-service-spring/templates/load-balance-istio.yaml
+++ b/mesh-test-service-spring/helm-templates/mesh-test-service-spring/templates/load-balance-istio.yaml
@@ -1,0 +1,79 @@
+{{- if eq .Values.SERVICE_MESH_TYPE "Istio" }}
+# Istio header-hash LB: /lb-header routes on public + internal gateways, DestinationRule on the dedicated
+# -lb Service hashes by X-User-Id (separate host avoids collision with the cookie DestinationRule).
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mesh-test-service-spring-lb-header-routes
+  labels:
+    app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
+    app.kubernetes.io/name: '{{ .Values.SERVICE }}'
+    app.kubernetes.io/processed-by-operator: "istiod"
+    deployment.netcracker.com/sessionId: '{{ .Values.DEPLOYMENT_SESSION_ID }}'
+spec:
+  parentRefs:
+    - name: public-gateway
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/{{ .Values.SERVICE }}/lb-header
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /api/v1/hello
+      backendRefs:
+        - kind: Service
+          name: mesh-test-service-spring-lb
+          port: 8080
+---
+# Internal path: route via internal-gateway-service Service so the waypoint applies the DestinationRule.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mesh-test-service-spring-lb-header-internal-routes
+  labels:
+    app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
+    app.kubernetes.io/name: '{{ .Values.SERVICE }}'
+    app.kubernetes.io/processed-by-operator: "istiod"
+    deployment.netcracker.com/sessionId: '{{ .Values.DEPLOYMENT_SESSION_ID }}'
+spec:
+  parentRefs:
+    - kind: Service
+      group: ''
+      name: internal-gateway-service
+      port: 8080
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/{{ .Values.SERVICE }}/lb-header
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /api/v1/hello
+      backendRefs:
+        - kind: Service
+          name: mesh-test-service-spring-lb
+          port: 8080
+---
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: mesh-test-service-spring-lb-header
+  labels:
+    app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
+    app.kubernetes.io/name: '{{ .Values.SERVICE }}'
+    deployment.netcracker.com/sessionId: '{{ .Values.DEPLOYMENT_SESSION_ID }}'
+spec:
+  host: mesh-test-service-spring-lb
+  trafficPolicy:
+    loadBalancer:
+      consistentHash:
+        httpHeaderName: X-User-Id
+{{- end }}

--- a/mesh-test-service-spring/helm-templates/mesh-test-service-spring/templates/load-balance-service.yaml
+++ b/mesh-test-service-spring/helm-templates/mesh-test-service-spring/templates/load-balance-service.yaml
@@ -1,0 +1,21 @@
+---
+# Dedicated host for header-hash LB (same pods) so its Istio DestinationRule doesn't collide with the cookie one.
+kind: Service
+apiVersion: v1
+metadata:
+  name: 'mesh-test-service-spring-lb'
+  annotations:
+    netcracker.cloud/start.stage: '0'
+  labels:
+    app.kubernetes.io/part-of: 'mesh-test-app'
+    app.kubernetes.io/name: '{{ .Values.SERVICE }}'
+spec:
+  ports:
+    - name: web
+      port: 8080
+      targetPort: 8080
+  selector:
+    name: '{{ .Values.DEPLOYMENT_RESOURCE_NAME }}'
+  {{ if and (eq .Values.K8S_SERVICE_TYPE "HEADLESS") (eq .Values.SERVICE_MESH_TYPE "Core") }}
+  clusterIP: None
+  {{ end }}

--- a/mesh-test-service-spring/helm-templates/mesh-test-service-spring/templates/stickiness-core.yaml
+++ b/mesh-test-service-spring/helm-templates/mesh-test-service-spring/templates/stickiness-core.yaml
@@ -1,0 +1,76 @@
+{{- if eq .Values.SERVICE_MESH_TYPE "Core" }}
+# Core cookie stickiness: /lb-test route on public + internal gateways, StatefulSession pins by cookie.
+---
+apiVersion: core.netcracker.com/v1
+kind: Mesh
+subKind: RouteConfiguration
+metadata:
+  name: mesh-test-service-spring-lb-test-routes
+  labels:
+    app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
+    app.kubernetes.io/name: '{{ .Values.SERVICE }}'
+    app.kubernetes.io/processed-by-operator: "core-operator"
+    deployment.netcracker.com/sessionId: '{{ .Values.DEPLOYMENT_SESSION_ID }}'
+spec:
+  gateways: ["public-gateway-service"]
+  virtualServices:
+    - name: public-gateway-service
+      hosts: ["*"]
+      routeConfiguration:
+        version: "{{ .Values.DEPLOYMENT_VERSION }}"
+        routes:
+          - destination:
+              cluster: "{{ .Values.SERVICE }}"
+              endpoint: http://{{ .Values.DEPLOYMENT_RESOURCE_NAME }}:8080
+            rules:
+              - match:
+                  prefix: /api/v1/{{ .Values.SERVICE }}/lb-test
+                allowed: true
+                prefixRewrite: /api/v1/hello
+---
+apiVersion: core.netcracker.com/v1
+kind: Mesh
+subKind: RouteConfiguration
+metadata:
+  name: mesh-test-service-spring-lb-test-internal-routes
+  labels:
+    app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
+    app.kubernetes.io/name: '{{ .Values.SERVICE }}'
+    app.kubernetes.io/processed-by-operator: "core-operator"
+    deployment.netcracker.com/sessionId: '{{ .Values.DEPLOYMENT_SESSION_ID }}'
+spec:
+  gateways: ["internal-gateway-service"]
+  virtualServices:
+    - name: internal-gateway-service
+      hosts: ["*"]
+      routeConfiguration:
+        version: "{{ .Values.DEPLOYMENT_VERSION }}"
+        routes:
+          - destination:
+              cluster: "{{ .Values.SERVICE }}"
+              endpoint: http://{{ .Values.DEPLOYMENT_RESOURCE_NAME }}:8080
+            rules:
+              - match:
+                  prefix: /api/v1/{{ .Values.SERVICE }}/lb-test
+                allowed: true
+                prefixRewrite: /api/v1/hello
+---
+apiVersion: core.netcracker.com/v1
+kind: Mesh
+subKind: StatefulSession
+metadata:
+  name: mesh-test-service-spring-sticky
+  labels:
+    app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
+    app.kubernetes.io/name: '{{ .Values.SERVICE }}'
+    app.kubernetes.io/processed-by-operator: "core-operator"
+    deployment.netcracker.com/sessionId: '{{ .Values.DEPLOYMENT_SESSION_ID }}'
+spec:
+  gateways: ["public-gateway-service", "internal-gateway-service"]
+  cluster: "{{ .Values.SERVICE }}"
+  enabled: true
+  cookie:
+    name: sticky-cookie-spring
+    ttl: 0
+    path: /
+{{- end }}

--- a/mesh-test-service-spring/helm-templates/mesh-test-service-spring/templates/stickiness-istio.yaml
+++ b/mesh-test-service-spring/helm-templates/mesh-test-service-spring/templates/stickiness-istio.yaml
@@ -1,0 +1,82 @@
+{{- if eq .Values.SERVICE_MESH_TYPE "Istio" }}
+# Istio cookie stickiness: /lb-test routes on public + internal gateways, host-level DestinationRule
+# hashes by cookie. One consistentHash per host, so header-based LB uses a separate Service.
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mesh-test-service-spring-lb-test-routes
+  labels:
+    app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
+    app.kubernetes.io/name: '{{ .Values.SERVICE }}'
+    app.kubernetes.io/processed-by-operator: "istiod"
+    deployment.netcracker.com/sessionId: '{{ .Values.DEPLOYMENT_SESSION_ID }}'
+spec:
+  parentRefs:
+    - name: public-gateway
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/{{ .Values.SERVICE }}/lb-test
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /api/v1/hello
+      backendRefs:
+        - kind: Service
+          name: "{{ .Values.DEPLOYMENT_RESOURCE_NAME }}"
+          port: 8080
+---
+# Internal path: route via internal-gateway-service Service so the waypoint applies the DestinationRule.
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mesh-test-service-spring-lb-test-internal-routes
+  labels:
+    app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
+    app.kubernetes.io/name: '{{ .Values.SERVICE }}'
+    app.kubernetes.io/processed-by-operator: "istiod"
+    deployment.netcracker.com/sessionId: '{{ .Values.DEPLOYMENT_SESSION_ID }}'
+spec:
+  parentRefs:
+    - kind: Service
+      group: ''
+      name: internal-gateway-service
+      port: 8080
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api/v1/{{ .Values.SERVICE }}/lb-test
+      filters:
+        - type: URLRewrite
+          urlRewrite:
+            path:
+              type: ReplacePrefixMatch
+              replacePrefixMatch: /api/v1/hello
+      backendRefs:
+        - kind: Service
+          name: "{{ .Values.DEPLOYMENT_RESOURCE_NAME }}"
+          port: 8080
+---
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: mesh-test-service-spring-sticky
+  labels:
+    app.kubernetes.io/part-of: '{{ .Values.APPLICATION_NAME }}'
+    app.kubernetes.io/name: '{{ .Values.SERVICE }}'
+    deployment.netcracker.com/sessionId: '{{ .Values.DEPLOYMENT_SESSION_ID }}'
+spec:
+  host: "{{ .Values.DEPLOYMENT_RESOURCE_NAME }}"
+  trafficPolicy:
+    loadBalancer:
+      consistentHash:
+        httpCookie:
+          name: sticky-cookie-spring
+          ttl: "0s"
+          path: /
+{{- end }}

--- a/mesh-test-service-spring/helm-templates/mesh-test-service-spring/values.yaml
+++ b/mesh-test-service-spring/helm-templates/mesh-test-service-spring/values.yaml
@@ -23,7 +23,8 @@ PRIVATE_GATEWAY_URL: '' # TO_BE_REPLACED
 PUBLIC_GATEWAY_URL: '' # TO_BE_REPLACED
 # revisionHistoryLimit value for DC
 RC_REVISIONS: 3
-REPLICAS: 1
+# 2 replicas so load-balancing / stickiness (same-pod pinning) is observable by the integration tests
+REPLICAS: 2
 # Openshift server host name
 SERVER_HOSTNAME: '' # TO_BE_REPLACED 
 # Number of IO threads in Undertow server


### PR DESCRIPTION
Cross-mesh IT for stickiness & load-balancing CRs

Adds `LoadBalanceIT` covering cookie stickiness (`StatefulSession`) and header-based
load balancing (`LoadBalance`), passing on both Core and Istio — the mesh is selected
by `SERVICE_MESH_TYPE` guards.

- **Test:** cookie + header-hash stickiness, parameterized over public & internal
  gateways.
- **Helm (`mesh-test-service-spring`):** stickiness & load-balance CRs for Core
  (`StatefulSession`/`LoadBalance`) and Istio (`DestinationRule`), a dedicated
  `-lb` Service for the header host, and `REPLICAS: 2`.