### PR TITLE
ci: add maas-agent-tag input to integration tests workflow

### DIFF
--- a/.github/actions/setup-kind-with-cloud-core/action.yml
+++ b/.github/actions/setup-kind-with-cloud-core/action.yml
@@ -28,6 +28,10 @@ inputs:
     description: Docker image tag for DBaaS Agent
     required: false
     default: latest
+  maas-agent-tag:
+    description: Docker image tag for MaaS Agent
+    required: false
+    default: latest
   core-operator-tag:
     description: Docker image tag for Core Operator
     required: false
@@ -111,6 +115,7 @@ runs:
         CONTROL_PLANE_TAG="${{ inputs.control-plane-tag }}"
         PAAS_MEDIATION_TAG="${{ inputs.paas-mediation-tag }}"
         DBAAS_AGENT_TAG="${{ inputs.dbaas-agent-tag }}"
+        MAAS_AGENT_TAG="${{ inputs.maas-agent-tag }}"
         CORE_OPERATOR_TAG="${{ inputs.core-operator-tag }}"
         CONFIG_SERVER_TAG="${{ inputs.config-server-tag }}"
         SITE_MANAGEMENT_TAG="${{ inputs.site-management-tag }}"
@@ -128,6 +133,9 @@ runs:
         fi
         if [ "$DBAAS_AGENT_TAG" != "latest" ] && [ -n "$DBAAS_AGENT_TAG" ]; then
           MAKE_ARGS="$MAKE_ARGS DBAAS_AGENT_TAG=$DBAAS_AGENT_TAG"
+        fi
+        if [ "$MAAS_AGENT_TAG" != "latest" ] && [ -n "$MAAS_AGENT_TAG" ]; then
+          MAKE_ARGS="$MAKE_ARGS MAAS_AGENT_TAG=$MAAS_AGENT_TAG"
         fi
         if [ "$CORE_OPERATOR_TAG" != "latest" ] && [ -n "$CORE_OPERATOR_TAG" ]; then
           MAKE_ARGS="$MAKE_ARGS CORE_OPERATOR_TAG=$CORE_OPERATOR_TAG"

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -73,6 +73,11 @@ on:
         required: false
         default: 'latest'
         type: string
+      maas-agent-tag:
+        description: 'Docker image tag for MaaS Agent'
+        required: false
+        default: 'latest'
+        type: string
       core-operator-tag:
         description: 'Docker image tag for Core Operator'
         required: false
@@ -98,7 +103,7 @@ on:
         required: false
         default: 'latest'
         type: string
-      mesh-test-quarkus-tag:  
+      mesh-test-quarkus-tag:
         description: 'Docker image tag for Mesh test Quarkus service'
         required: false
         default: 'latest'
@@ -107,7 +112,7 @@ on:
         description: 'Docker image tag for Mesh test Go service'
         required: false
         default: 'latest'
-        type: string        
+        type: string
       dummy-separator-2:
         description: '--------------------------------'
         required: false
@@ -200,6 +205,11 @@ on:
         required: false
         default: 'latest'
         type: string
+      maas-agent-tag:
+        description: 'Docker image tag for MaaS Agent'
+        required: false
+        default: 'latest'
+        type: string
       core-operator-tag:
         description: 'Docker image tag for Core Operator'
         required: false
@@ -288,6 +298,7 @@ jobs:
             echo "| control-plane-tag | \`${{ inputs.control-plane-tag || 'latest' }}\` |"
             echo "| paas-mediation-tag | \`${{ inputs.paas-mediation-tag || 'latest' }}\` |"
             echo "| dbaas-agent-tag | \`${{ inputs.dbaas-agent-tag || 'latest' }}\` |"
+            echo "| maas-agent-tag | \`${{ inputs.maas-agent-tag || 'latest' }}\` |"
             echo "| core-operator-tag | \`${{ inputs.core-operator-tag || 'latest' }}\` |"
             echo "| config-server-tag | \`${{ inputs.config-server-tag || 'latest' }}\` |"
             echo "| site-management-tag | \`${{ inputs.site-management-tag || 'latest' }}\` |"
@@ -312,6 +323,7 @@ jobs:
           echo "control-plane-tag=${{ inputs.control-plane-tag || 'latest' }}"
           echo "paas-mediation-tag=${{ inputs.paas-mediation-tag || 'latest' }}"
           echo "dbaas-agent-tag=${{ inputs.dbaas-agent-tag || 'latest' }}"
+          echo "maas-agent-tag=${{ inputs.maas-agent-tag || 'latest' }}"
           echo "core-operator-tag=${{ inputs.core-operator-tag || 'latest' }}"
           echo "config-server-tag=${{ inputs.config-server-tag || 'latest' }}"
           echo "site-management-tag=${{ inputs.site-management-tag || 'latest' }}"
@@ -336,6 +348,7 @@ jobs:
           control-plane-tag: ${{ inputs.control-plane-tag || 'latest' }}
           paas-mediation-tag: ${{ inputs.paas-mediation-tag || 'latest' }}
           dbaas-agent-tag: ${{ inputs.dbaas-agent-tag || 'latest' }}
+          maas-agent-tag: ${{ inputs.maas-agent-tag || 'latest' }}
           core-operator-tag: ${{ inputs.core-operator-tag || 'latest' }}
           config-server-tag: ${{ inputs.config-server-tag || 'latest' }}
           site-management-tag: ${{ inputs.site-management-tag || 'latest' }}


### PR DESCRIPTION
## Why

The MaaS Agent image tag could not be pinned from the integration tests workflow, unlike every other Cloud Core component.

## What

- New `maas-agent-tag` input (default `latest`) in both `workflow_call` and `workflow_dispatch`, reported in the workflow input summary.
- The value is passed to the `setup-kind-with-cloud-core` action, which forwards it to the bootstrap Makefile as `MAAS_AGENT_TAG` when it differs from `latest`.

## How to verify

Run the workflow with `install-maas: true` and `maas-agent-tag: <tag>`, then check that the `maas-agent` deployment uses that image tag. With `install-maas: false` the input has no effect, since `deploy-maas-agent` is skipped.
